### PR TITLE
install ninja

### DIFF
--- a/install.py
+++ b/install.py
@@ -2,3 +2,7 @@ import launch
 
 if not launch.is_installed('dlib-bin'):
     launch.run_pip('install dlib-bin')
+
+if not launch.is_installed('ninja'):
+    launch.run_pip('install ninja')
+


### PR DESCRIPTION
when I test on windows it tells me it's missing `ninja`
not sure if this is also needed on linux

after `ninja` is installed it still give me some strange issue 
basically the same as this
- https://github.com/rosinality/stylegan2-pytorch/issues/325
which is somehow resolved by manually copying `python310.lib` as shownwd in comment
- https://github.com/rosinality/stylegan2-pytorch/issues/325#issuecomment-1192107558

you might want to add this to you readme / troubleshooting

or you could try `extra_ldflags` stuff from
- https://github.com/rosinality/stylegan2-pytorch/issues/325#issuecomment-2144399296